### PR TITLE
Fix werf's `artifact` directive deprecation warning

### DIFF
--- a/.werf/stages/release.yaml
+++ b/.werf/stages/release.yaml
@@ -1,6 +1,7 @@
 # Release image, stored in your.registry.io/modules/<module-name>/release:<semver>
 ---
-artifact: release-channel-version-artifact
+image: release-channel-version-artifact
+final: false
 from: registry.deckhouse.io/base_images/alpine:3.20.3
 shell:
   install:
@@ -9,7 +10,7 @@ shell:
 image: release-channel-version
 from: registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc
 import:
-  - artifact: release-channel-version-artifact
+  - image: release-channel-version-artifact
     add: /
     to: /
     after: install


### PR DESCRIPTION
Fix werf's artifact directive deprecation warning when module releases.