### PR TITLE
fix: werf template and module.yaml

### DIFF
--- a/hooks/batch/https/copy_custom_certificate.go
+++ b/hooks/batch/https/copy_custom_certificate.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package copycustomcertificate
 
 import (

--- a/hooks/batch/main.go
+++ b/hooks/batch/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/hooks/batch/main_test.go
+++ b/hooks/batch/main_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main_test
 
 import (

--- a/hooks/batch/readiness.go
+++ b/hooks/batch/readiness.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/module.yaml
+++ b/module.yaml
@@ -1,5 +1,5 @@
 name: echoserver
-stage: Sandbox
+stage: Preview
 weight: 960
 requirements:
     deckhouse: ">= 1.69"

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -4,5 +4,6 @@ config:
     allowEnvVariables:
     - /CI_.+/
     - MODULES_MODULE_TAG
+    - STAGED_DOCKERFILE
     allowUncommittedFiles:
     - "base_images.yml"

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -4,6 +4,6 @@ config:
     allowEnvVariables:
     - /CI_.+/
     - MODULES_MODULE_TAG
-    - STAGED_DOCKERFILE
+    - STAGED_DOCKERFILE   # Allow the use of these variable in the .werf/stages/images.yaml file
     allowUncommittedFiles:
     - "base_images.yml"


### PR DESCRIPTION
This pull request includes several changes to add licensing headers to source files, update the module stage, and adjust configuration settings. Below is a summary of the most important changes:

### Licensing Updates:
* Added Apache 2.0 license headers to the following files to ensure compliance with open-source licensing requirements:
  - `hooks/batch/https/copy_custom_certificate.go`
  - `hooks/batch/main.go`
  - `hooks/batch/main_test.go`
  - `hooks/batch/readiness.go`

### Module Configuration:
* Updated the `stage` of the `echoserver` module in `module.yaml` from "Sandbox" to "Preview" to reflect its progression in the development lifecycle.

### Giterminism Configuration:
* Added `STAGED_DOCKERFILE` to the `allowEnvVariables` list in `werf-giterminism.yaml` to permit its usage in the build process.