### PR TITLE
fix werf config error

### DIFF
--- a/.werf/stages/release.yaml
+++ b/.werf/stages/release.yaml
@@ -12,4 +12,3 @@ git:
     to: /
     includePaths:
       - module.yaml
-    after: install


### PR DESCRIPTION
`after: install` causes build error:

```
Error: unable to load werf config: unknown fields: `after`!
    add: /
    to: /
    includePaths:
    - module.yaml
    after: install
```