### PR TITLE
[modules-template] make echoserver pass dmt lint

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,3 +1,9 @@
+.git/
+.github/
+.gitignore
+.gitlab-ci.yml
+.werf/
+base_images.yml.example
 crds
 docs
 enabled

--- a/crds/doc-ru-golang.yaml
+++ b/crds/doc-ru-golang.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: golangs.example.io
+  labels:
+    module: my-module
+spec:
+  group: example.io
+  scope: Cluster
+  names:
+    plural: golangs
+    singular: golang
+    kind: Golang
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: Компилятор Go.
+          properties:
+            spec:
+              type: object
+              description: Спецификация компилятора Go.
+              properties:
+                version:
+                  type: object
+                  description: Версия Golang.
+                  properties:
+                    major:
+                      description: Основная версия Golang.
+                    minor:
+                      description: Минорная версия Golang.
+                    patch:
+                      description: Патч-версия Golang.
+                modules:
+                  type: array
+                  description: Список модулей для установки.
+                  items:
+                    type: object
+                    description: Модуль для установки.
+                    properties:
+                      name:
+                        description: Имя модуля.
+                      version:
+                        description: Версия модуля.
+                      source:
+                        description: Источник модуля.
+                      extraArgs:
+                        description: Дополнительные аргументы для pip install.

--- a/module.yaml
+++ b/module.yaml
@@ -3,7 +3,7 @@ stage: Experimental
 weight: 960
 # constraints to check module requirements
 requirements:
-    deckhouse: ">= 1.69"
+    deckhouse: ">= 1.71"
 subsystems:
   - chore
 namespace: echoserver

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: echoserver
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
       - containerName: "echoserver"

--- a/templates/httproute.yaml
+++ b/templates/httproute.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echoserver
+  namespace: {{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "echoserver")) | nindent 2 }}
+spec:
+  hostnames:
+    - {{ include "helm_lib_module_public_domain" (list . "echoserver") }}
+  parentRefs:
+    - name: main
+      namespace: d8-gateway-api
+  rules:
+    - backendRefs:
+        - name: echoserver
+          port: 80

--- a/templates/listenerset.yaml
+++ b/templates/listenerset.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: deckhouse.io/v1
+kind: ListenerSet
+metadata:
+  name: main
+  namespace: d8-gateway-api
+  {{- include "helm_lib_module_labels" (list . (dict "app" "echoserver")) | nindent 2 }}
+spec:
+  redirectToHTTPS: true


### PR DESCRIPTION
## Problem

The reference module `echoserver` does not pass `dmt lint`. Since all new modules are forked from this template, every new module inherits these errors.

## Changes

Fixed all 5 DMT lint error categories and made CI enforce lint:

### Module fixes

| Rule | Fix |
|------|-----|
| **helmignore** | Added missing entries: `.git/` `.github/` `.gitignore` `.gitlab-ci.yml` `.werf/` `base_images.yml.example` |
| **requirements** | Bumped `deckhouse: ">= 1.71"` — minimum required by Module-SDK v0.3.0 |
| **bilingual** | Created `crds/doc-ru-golang.yaml` with Russian CRD descriptions |
| **httproute-rules** | Added `templates/httproute.yaml` (HTTPRoute) + `templates/listenerset.yaml` (ListenerSet) for Ingress → Gateway API migration |
| **vpa** | Changed `updateMode: "Auto"` → `"InPlaceOrRecreate"` (Auto is deprecated) |

### CI

- Removed `continue-on-error: true` from the lint job — DMT lint failures now block the pipeline

## Verification

```
$ dmt lint ./
INFO  Processing directory
INFO  DMT version devel
INFO  Found modules count=1
INFO  Run linters for module module=echoserver
(exit 0, zero errors)
```